### PR TITLE
fix: update work email translation string to be email

### DIFF
--- a/src/lib/translations/en-GB.json
+++ b/src/lib/translations/en-GB.json
@@ -106,7 +106,7 @@
         "new-atlas-password-message": " Please pick a new Atlas password",
         "atlas-signup": "Sign up to Atlas",
         "atlas-signup-message": "Welcome! Sign up with your email or a third party account to get started today.",
-        "work-email": "Your work email",
+        "work-email": "email",
         "invalid-email": "Invalid email address",
         "register-password": "Your password",
         "help": "Need help?",


### PR DESCRIPTION
As requested in https://github.com/weareatlas/weareatlas/issues/594